### PR TITLE
Implement sdt::error:Error and change debug logging

### DIFF
--- a/src/xmodem.rs
+++ b/src/xmodem.rs
@@ -80,11 +80,11 @@ impl Xmodem {
     pub fn send<D: Read + Write, R: Read>(&mut self, dev: &mut D, stream: &mut R) -> Result<()> {
         self.errors = 0;
 
-        dbg!("Starting XMODEM transfer");
+        debug!("Starting XMODEM transfer");
         (self.start_send(dev))?;
-        dbg!("First byte received. Sending stream.");
+        debug!("First byte received. Sending stream.");
         (self.send_stream(dev, stream))?;
-        dbg!("Sending EOT");
+        debug!("Sending EOT");
         (self.finish_send(dev))?;
 
         Ok(())
@@ -111,7 +111,7 @@ impl Xmodem {
         self.errors = 0;
         self.checksum_mode = checksum;
         let mut handled_first_packet = false;
-        dbg!("Starting XMODEM receive");
+        debug!("Starting XMODEM receive");
 
         let first_char;
         loop {
@@ -138,7 +138,7 @@ impl Xmodem {
                 }
             }
         }
-        dbg!("NCG sent. Receiving stream.");
+        debug!("NCG sent. Receiving stream.");
         let mut packet_num: u8 = 1;
         loop {
             match if handled_first_packet {
@@ -220,12 +220,12 @@ impl Xmodem {
             match (get_byte_timeout(dev))? {
                 Some(c) => match c {
                     NAK => {
-                        dbg!("Standard checksum requested");
+                        debug!("Standard checksum requested");
                         self.checksum_mode = Checksum::Standard;
                         return Ok(());
                     }
                     CRC => {
-                        dbg!("16-bit CRC requested");
+                        debug!("16-bit CRC requested");
                         self.checksum_mode = Checksum::CRC16;
                         return Ok(());
                     }
@@ -267,7 +267,7 @@ impl Xmodem {
             let mut buff = vec![self.pad_byte; self.block_length as usize + 3];
             let n = (stream.read(&mut buff[3..]))?;
             if n == 0 {
-                dbg!("Reached EOF");
+                debug!("Reached EOF");
                 return Ok(());
             }
 
@@ -291,13 +291,13 @@ impl Xmodem {
                 }
             }
 
-            dbg!("Sending block {}", block_num);
+            debug!("Sending block {}", block_num);
             (dev.write_all(&buff))?;
 
             match (get_byte_timeout(dev))? {
                 Some(c) => {
                     if c == ACK {
-                        dbg!("Received ACK for block {}", block_num);
+                        debug!("Received ACK for block {}", block_num);
                         continue;
                     } else {
                         warn!("Expected ACK, got {}", c);

--- a/src/xmodem.rs
+++ b/src/xmodem.rs
@@ -3,7 +3,6 @@ pub use xymodem_util::*;
 
 // TODO: Send CAN byte after too many errors
 // TODO: Handle CAN bytes while sending
-// TODO: Implement Error for Error
 
 const SOH: u8 = 0x01;
 const STX: u8 = 0x02;

--- a/src/xymodem_util.rs
+++ b/src/xymodem_util.rs
@@ -1,4 +1,8 @@
-use std::io::{self, Read};
+use std::{
+    fmt::Display,
+    fmt::Formatter,
+    io::{self, Read},
+};
 
 pub fn calc_checksum(data: &[u8]) -> u8 {
     data.iter().fold(0, |x, &y| x.wrapping_add(y))
@@ -45,3 +49,15 @@ pub enum Error {
     /// The transmission was canceled by the other end of the channel.
     Canceled,
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(io_err) => io_err.fmt(f),
+            Error::ExhaustedRetries => write!(f, "Transfer retries exhuasted"),
+            Error::Canceled => write!(f, "Transfer canceled"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/ymodem.rs
+++ b/src/ymodem.rs
@@ -76,7 +76,7 @@ impl Ymodem {
         let mut file_buf: Vec<u8> = Vec::new();
 
         self.errors = 0;
-        dbg!("Starting YMODEM receive");
+        debug!("Starting YMODEM receive");
         // Initialize transfer
         loop {
             (dev.write(&[CRC])?);
@@ -189,7 +189,6 @@ impl Ymodem {
         let mut received_first_eot = false;
 
         for range in 0..(num_of_packets + 3) {
-            dbg!(range);
             match get_byte_timeout(dev)? {
                 bt @ Some(SOH) | bt @ Some(STX) => {
                     // Handle next packet
@@ -282,13 +281,13 @@ impl Ymodem {
         let packets_to_send = f64::ceil(file_size_in_bytes as f64 / 1024.0) as u32;
         let last_packet_size = file_size_in_bytes % 1024;
 
-        dbg!("Starting YMODEM transfer");
+        debug!("Starting YMODEM transfer");
         (self.start_send(dev))?;
-        dbg!("First byte received. Sending start frame.");
+        debug!("First byte received. Sending start frame.");
         (self.send_start_frame(dev, file_name, file_size_in_bytes))?;
-        dbg!("Start frame acknowledged. Sending stream.");
+        debug!("Start frame acknowledged. Sending stream.");
         (self.send_stream(dev, stream, packets_to_send, last_packet_size))?;
-        dbg!("Sending EOT");
+        debug!("Sending EOT");
         (self.finish_send(dev))?;
 
         Ok(())
@@ -300,7 +299,7 @@ impl Ymodem {
             match (get_byte_timeout(dev))? {
                 Some(c) => match c {
                     CRC => {
-                        dbg!("16-bit CRC requested");
+                        debug!("16-bit CRC requested");
                         return Ok(());
                     }
                     CAN => {
@@ -369,7 +368,7 @@ impl Ymodem {
             match (get_byte_timeout(dev))? {
                 Some(c) => {
                     if c == ACK {
-                        dbg!("Received ACK for start frame");
+                        debug!("Received ACK for start frame");
                         break;
                     } else {
                         warn!("Expected ACK, got {}", c);
@@ -393,7 +392,7 @@ impl Ymodem {
             match (get_byte_timeout(dev))? {
                 Some(c) => {
                     if c == CRC {
-                        dbg!("Received C for start frame");
+                        debug!("Received C for start frame");
                         break;
                     } else {
                         warn!("Expected C, got {}", c);
@@ -433,7 +432,7 @@ impl Ymodem {
             let mut buff = vec![self.pad_byte; packet_size as usize + 3];
             let n = (stream.read(&mut buff[3..]))?;
             if n == 0 {
-                dbg!("Reached EOF");
+                debug!("Reached EOF");
                 return Ok(());
             }
 
@@ -446,13 +445,13 @@ impl Ymodem {
             buff.push(((crc >> 8) & 0xFF) as u8);
             buff.push((crc & 0xFF) as u8);
 
-            println!("Sending block {}", block_num);
+            debug!("Sending block {} of {}", block_num, packets_to_send);
             (dev.write_all(&buff))?;
 
             match (get_byte_timeout(dev))? {
                 Some(c) => {
                     if c == ACK {
-                        dbg!("Received ACK for block {}", block_num);
+                        debug!("Received ACK for block {}", block_num);
                         continue;
                     } else {
                         warn!("Expected ACK, got {}", c);
@@ -571,7 +570,7 @@ impl Ymodem {
             match (get_byte_timeout(dev))? {
                 Some(c) => {
                     if c == ACK {
-                        dbg!("Received ACK for start frame");
+                        debug!("Received ACK for start frame");
                         break;
                     } else {
                         warn!("Expected ACK, got {}", c);

--- a/src/ymodem.rs
+++ b/src/ymodem.rs
@@ -356,6 +356,7 @@ impl Ymodem {
 
         for byte in format!("{:x}", file_size_in_bytes).as_bytes() {
             buff[curr_buff_idx] = *byte;
+            curr_buff_idx += 1;
         }
 
         let crc = calc_crc(&buff[3..]);

--- a/src/ymodem.rs
+++ b/src/ymodem.rs
@@ -481,6 +481,9 @@ impl Ymodem {
                 Some(c) => {
                     if c == NAK {
                         break;
+                    } else if c == ACK {
+                        log::info!("Expected NAK for EOT, got ACK");
+                        break;
                     } else {
                         log::warn!("Expected ACK, got {}", c);
                     }

--- a/src/ymodem.rs
+++ b/src/ymodem.rs
@@ -3,7 +3,6 @@ pub use xymodem_util::*;
 
 // TODO: Send CAN byte after too many errors
 // TODO: Handle CAN bytes while sending
-// TODO: Implement Error for Error
 
 const SOH: u8 = 0x01;
 const STX: u8 = 0x02;


### PR DESCRIPTION
I was looking for a rust implementation of ymodem and found this which does the job nicely.

the `dbg!` macro use was making it hard to see my output so this changes them to `log::debug!`
and also implement `std::error::Error` so that my lazy error hanglind with anyhow works.

It also has a small hack to the EOT logic to make it work with the device I am talking to 